### PR TITLE
[TT-3352] Ensure roles currently in use cannot be deleted

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3
+  - 2.4
+  - 2.5
 script: "bundle exec rake spec"
 gemfile:
   - gemfiles/rails4.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.3.0
 script: "bundle exec rake spec"
 gemfile:
-  - gemfiles/rails3.gemfile
   - gemfiles/rails4.gemfile
   - gemfiles/rails5.gemfile
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ### Fixed
 - [TT-3352] Ensure roles currently in use cannot be deleted
+- Also dropped rails 3 support due to above
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+### Fixed
+- [TT-3352] Ensure roles currently in use cannot be deleted
+
 ## 0.3.0
 
 ### Fixed

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-gemspec :path => '../'
-
-group :development, :test do
-  gem 'rails', '~> 3.2.0'
-  gem 'rails_4_backports' # find_by
-end

--- a/lib/right_on/role_model.rb
+++ b/lib/right_on/role_model.rb
@@ -1,7 +1,9 @@
 module RightOn
   module RoleModel
     def self.included(base)
-      base.module_eval 'has_and_belongs_to_many :roles, :class_name => "RightOn::Role"'
+      base.module_eval do
+        has_and_belongs_to_many :roles, class_name: 'RightOn::Role'
+      end
       Role.module_eval do
         has_and_belongs_to_many base.table_name.to_sym, dependent: :restrict
       end

--- a/lib/right_on/role_model.rb
+++ b/lib/right_on/role_model.rb
@@ -3,18 +3,11 @@ module RightOn
     def self.included(base)
       base.module_eval do
         has_and_belongs_to_many :roles, class_name: 'RightOn::Role'
+        has_many :rights, through: :roles, class_name: 'RightOn::Right'
       end
       Role.module_eval do
         has_and_belongs_to_many base.table_name.to_sym, dependent: :restrict
       end
-    end
-
-    def rights
-      @rights ||=
-        Right
-          .select('distinct rights.*')
-          .joins(:roles)
-          .where('rights_roles.role_id IN (?)', role_ids)
     end
 
     def has_privileges_of?(other_user)

--- a/lib/right_on/role_model.rb
+++ b/lib/right_on/role_model.rb
@@ -2,7 +2,9 @@ module RightOn
   module RoleModel
     def self.included(base)
       base.module_eval 'has_and_belongs_to_many :roles, :class_name => "RightOn::Role"'
-      Role.module_eval "has_and_belongs_to_many :#{base.table_name}, dependent: :restrict"
+      Role.module_eval do
+        has_and_belongs_to_many base.table_name.to_sym, dependent: :restrict
+      end
     end
 
     def rights

--- a/lib/right_on/role_model.rb
+++ b/lib/right_on/role_model.rb
@@ -2,7 +2,7 @@ module RightOn
   module RoleModel
     def self.included(base)
       base.module_eval 'has_and_belongs_to_many :roles, :class_name => "RightOn::Role"'
-      Role.module_eval "has_and_belongs_to_many :#{base.table_name}"
+      Role.module_eval "has_and_belongs_to_many :#{base.table_name}, dependent: :restrict"
     end
 
     def rights

--- a/right_on.gemspec
+++ b/right_on.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activerecord', '>= 3.2.0'
-  spec.add_dependency 'activesupport', '>= 3.2.0'
+  spec.add_dependency 'activerecord', '>= 4.0.0'
+  spec.add_dependency 'activesupport', '>= 4.0.0'
   spec.add_dependency 'input_reader', '~> 0.0'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/spec/right_on_spec.rb
+++ b/spec/right_on_spec.rb
@@ -1,19 +1,5 @@
 require 'spec_helper'
 
-describe User do
-  let(:basic_user) { User.where(name: 'basic').first }
-  let(:admin_user) { User.where(name: 'admin').first }
-
-  before do
-    Bootstrap.reset_database
-  end
-
-  it 'should compare privileges' do
-    expect(admin_user.has_privileges_of?(basic_user)).to eq true
-    expect(basic_user.has_privileges_of?(admin_user)).to eq false
-  end
-end
-
 describe RightOn::Right do
   before do
     RightOn::Right.delete_all

--- a/spec/role_model_spec.rb
+++ b/spec/role_model_spec.rb
@@ -25,4 +25,9 @@ describe RightOn::RoleModel do
     expect(admin.has_privileges_of?(basic_user)).to be true
     expect(basic_user.has_privileges_of?(admin)).to be false
   end
+
+  it 'links back to users' do
+    admin # load admin
+    expect(admin_role.users.size).to eq 1
+  end
 end


### PR DESCRIPTION
**WHY** - We don't want to delete roles if people are using them, this could lead to loss of access

**TESTING** - Delete roles before this and it allows, after it does not.

I'm not sure why we don't also have to update this to fix this. It looks like we have some duplicate code across the projects. @blaknite might know?

https://github.com/sealink/cancanright/blob/master/lib/cancanright/role_model.rb