### PR TITLE
Extract rights_yaml to where it is used (in ByGroups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ### Improved
 - Improve tests for RightOn::ByGroup
+- Internal improvement of RightOn::ByGroup
 
 ### Fixed
 - [TT-3352] Ensure roles currently in use cannot be deleted

--- a/lib/right_on.rb
+++ b/lib/right_on.rb
@@ -4,4 +4,12 @@ module RightOn
   require 'rails'
   require 'right_on/railtie'
   require 'right_on/rights_manager'
+
+  def self.rights_yaml(file_path = nil)
+    if file_path
+      @rights_yaml = file_path
+    else
+      @rights_yaml
+    end
+  end
 end

--- a/lib/right_on/by_group.rb
+++ b/lib/right_on/by_group.rb
@@ -1,23 +1,24 @@
 module RightOn
   class ByGroup
+    def self.rights
+      new.by_groups
+    end
+
     def initialize
       @rights_by_name = Hash[Right.all.map{|r| [r.name, r]}]
     end
 
     def by_groups
-      rights = regular_rights_with_group
-      rights += (Right.all - rights)
-      rights.group_by(&:group)
+      yaml_rights.each_pair.with_object({}) do |(group, right_names), hash|
+        hash[group] = right_names
+          .flat_map { |right_name| right_name_to_rights(right_name) }
+      end
     end
 
     private
 
-    def regular_rights_with_group
-      RightOn::Right.yaml_rights.each_pair.flat_map do |group, right_names|
-        right_names
-          .flat_map { |right_name| right_name_to_rights(right_name) }
-          .each { |r| r.group = group }
-      end
+    def yaml_rights
+      YAML::load_file(RightOn.rights_yaml)['rights']
     end
 
     def right_name_to_rights(right_name)

--- a/lib/right_on/by_group.rb
+++ b/lib/right_on/by_group.rb
@@ -18,7 +18,7 @@ module RightOn
     private
 
     def yaml_rights
-      YAML::load_file(RightOn.rights_yaml)['rights']
+      YAML.load_file(RightOn.rights_yaml)['rights']
     end
 
     def right_name_to_rights(right_name)

--- a/lib/right_on/right.rb
+++ b/lib/right_on/right.rb
@@ -13,22 +13,6 @@ module RightOn
     after_save :clear_cache
     after_destroy :clear_cache
 
-    attr_accessor :group
-
-    class << self
-      def rights_yaml(file_path)
-        @@rights_yaml = file_path
-      end
-
-      def by_groups
-        RightOn::ByGroup.new.by_groups
-      end
-
-      def yaml_rights
-        YAML::load_file(@@rights_yaml)['rights']
-      end
-    end
-
     # Is this right allowed for the given context?
     #
     # Context params is an option hash:

--- a/spec/by_group_spec.rb
+++ b/spec/by_group_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-RightOn::Right.rights_yaml 'db/rights_roles.yml'
+RightOn.rights_yaml 'db/rights_roles.yml'
 
 describe RightOn::ByGroup do
   let(:rights) { Bootstrap.various_rights_with_actions }
 
   it 'should identify correct groups' do
     rights # load rights
-    expect(RightOn::Right.by_groups).to eq(
+    expect(RightOn::ByGroup.rights).to eq(
       'general' => [
         rights[:models],
         rights[:models_index],

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 91.7)
+Coverage::Kit.setup(minimum_coverage: 91.3)


### PR DESCRIPTION
Simplify ByGroup code, no need to make 'group' an accessor since it's virtual, just calculate that in the task.

Coverage had to be dropped as lines removed (actual coverage is the same). This is due to untested controller code which I plan to put in cancanright.